### PR TITLE
Added direct links to privacy and tos in content-guidelines

### DIFF
--- a/docs/for-content-creators/content-guidelines.md
+++ b/docs/for-content-creators/content-guidelines.md
@@ -58,4 +58,4 @@ The daily.dev community is highly sensitive to content quality and the code of c
 
 ## Some legal stuff...
 
-Daily Dev Ltd. does not claim ownership or copyright to any of the submitted sources. If a copyright infringement claim is made regarding the submitted source, the content will be removed and the submitted user might be blocked from future submissions. Read more about our Privacy Policy and Terms of Service.
+Daily Dev Ltd. does not claim ownership or copyright to any of the submitted sources. If a copyright infringement claim is made regarding the submitted source, the content will be removed and the submitted user might be blocked from future submissions. Read more about our [Privacy Policy](https://daily.dev/privacy) and [Terms of Service](https://daily.dev/tos).


### PR DESCRIPTION
Closes(#40 )
I have added the direct links to terms of service and privacy in the content-guidelines page.
![image](https://user-images.githubusercontent.com/65999534/148943197-607f73e1-e70a-4aa9-8f0c-759068908041.png)
