### PR TITLE
remove frequency statement from the content guidelines

### DIFF
--- a/docs/for-content-creators/content-guidelines.md
+++ b/docs/for-content-creators/content-guidelines.md
@@ -20,7 +20,7 @@ Learn [how to submit a new source request](/for-content-creators/suggest-new-sou
 
 ✅ Sources that are generating exciting and professional content.
 
-✅ Sources that publish new content regularly (at least once a week).
+✅ Sources that publish new content regularly.
 
 ✅ Sources that have published a substantial amount of content to date.
 


### PR DESCRIPTION
While reviewing a source I usually check for the frequency but not necessarily once a week.
It's subjective because it also depends on the content quality and the topic.
It's better to remove it for the time being.