### PR TITLE
Fixed the Product Hunt link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -204,7 +204,7 @@ const config = {
               },
               {
                 label: 'Product Hunt',
-                to: 'https://www.producthunt.com/posts/daily-dev-2',
+                to: 'https://www.producthunt.com/products/daily-dev',
               },
             ],
           },


### PR DESCRIPTION
I'm a PM at Product Hunt and saw some traffic coming from you guys. Just poking around and noticed you have a link to a post page instead of one of our new hubs. Cheers