### PR TITLE
replaced a full stop with an exclamation mark

### DIFF
--- a/docs/getting-started/browser-extension-installation.md
+++ b/docs/getting-started/browser-extension-installation.md
@@ -12,7 +12,7 @@ The daily.dev extension is available for:
 - [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/daily/)
 - [Microsoft Edge](https://microsoftedge.microsoft.com/addons/detail/dailydev-the-homepage-/cbdhgldgiancdheindpekpcbkccpjaeb?hl=en-GB)
 
-Just install it, open a new tab, and you're all set.
+Just install it, open a new tab, and you're all set!
 
 ## Using Safari? Brave? Opera? Vivaldi? Other Browser?
 


### PR DESCRIPTION
I think an exclamation mark after a new user installs the extension captures the excitement better!

So, it should be `Just install it, open a new tab, and you're all set!` like how it is for `Try our progressive web app!`
![image](https://user-images.githubusercontent.com/62152915/179098996-db7e6cba-0993-4fad-8e82-733623aebbdb.png)


This fixes the issue: #86 