### PR TITLE
added a section to the top of the community picks guidance

### DIFF
--- a/docs/how-does-daily-dev-work/community-picks-submission-guidelines.md
+++ b/docs/how-does-daily-dev-work/community-picks-submission-guidelines.md
@@ -5,7 +5,7 @@ sidebar_label: "Community Picks Guidelines"
 # Community Picks Submission Guidelines
 
 ## What are Community Picks?
-Community Picks are articles that are scouted out and submitted by the community, that then appear in the daily.dev feed like any other article.
+Community Picks are articles that are scouted out and submitted by the community. These articles then appear in the daily.dev feed like any other article.
 
 Nearly any article, from nearly any website can be submitted as long as it is related to tech / development, and subequently enjoyed by the entire daily.dev community.
 

--- a/docs/how-does-daily-dev-work/community-picks-submission-guidelines.md
+++ b/docs/how-does-daily-dev-work/community-picks-submission-guidelines.md
@@ -13,7 +13,7 @@ To get access to this feature you first need to earn the Scout privilege (min. 2
 
 **You can read more about how to [submit and use Community Picks here.](https://docs.daily.dev/docs/key-features/community-picks)** 
 
-## General rule / quick guidance
+## General guidlines on submitting Community Picks
 We want you to submit articles that made a real difference to your tech journey. Whether they are in-depth tutorials, interesting perspectives on tech problems, or well thought out and high effort entertainment pieces aimed at developers.
 
 Above all, we want articles that you believe need more exposure, from authors you admire, that you believe will benefit the daily.dev developer community.

--- a/docs/how-does-daily-dev-work/community-picks-submission-guidelines.md
+++ b/docs/how-does-daily-dev-work/community-picks-submission-guidelines.md
@@ -7,7 +7,7 @@ sidebar_label: "Community Picks Guidelines"
 ## What are Community Picks?
 Community Picks are articles that are scouted out and submitted by the community. These articles then appear in the daily.dev feed like any other article.
 
-Nearly any article, from nearly any website can be submitted as long as it is related to tech / development, and subequently enjoyed by the entire daily.dev community.
+Nearly any article, from nearly any website can be submitted as long as it is related to tech / development, and subequently can be enjoyed by the entire daily.dev community.
 
 To get access to this feature you first need to earn the Scout privilege (min. 250 reputation points). Only people with the Scout privilege can submit links and are limited to 3 submissions per day.
 

--- a/docs/how-does-daily-dev-work/community-picks-submission-guidelines.md
+++ b/docs/how-does-daily-dev-work/community-picks-submission-guidelines.md
@@ -4,12 +4,14 @@ sidebar_label: "Community Picks Guidelines"
 ---
 # Community Picks Submission Guidelines
 
-When submitting Community Picks for the daily.dev community, it is important to understand the type of articles and quality of articles we are (and are not) looking for.
+## What are Community Picks?
+Community Picks are articles that are scouted out and submitted by the community, that then appear in the daily.dev feed like any other article.
 
+Nearly any article, from nearly any website can be submitted as long as it is related to tech / development, and subequently enjoyed by the entire daily.dev community.
 
-:::info
-The Community Picks feature is still in Beta, as such this guidelines are provisional and are likely to change to ensure we uphold high standards on the daily.dev feed
-:::
+To get access to this feature you first need to earn the Scout privilege (min. 250 reputation points). Only people with the Scout privilege can submit links and are limited to 3 submissions per day.
+
+**You can read more about how to [submit and use Community Picks here.](https://docs.daily.dev/docs/key-features/community-picks)** 
 
 ## General rule / quick guidance
 We want you to submit articles that made a real difference to your tech journey. Whether they are in-depth tutorials, interesting perspectives on tech problems, or well thought out and high effort entertainment pieces aimed at developers.
@@ -19,6 +21,10 @@ Above all, we want articles that you believe need more exposure, from authors yo
 Low effort, poor quality and (self) promotional content will be removed to ensure a high standard on the platform.
 
 ## Guidelines
+:::info
+The Community Picks feature is still in Beta, as such this guidelines are provisional and are likely to change to ensure we uphold high standards on the daily.dev feed
+:::
+
 We work hard to ensure that we only intervene on low quality, low effort and or repetitive articles that do not benefit the community, and not in any way that introduces bias towards any one point of view.
 
 Hopefully the following guidelines will help you ensure that articles you scout out for the community are well received:

--- a/docs/how-does-daily-dev-work/community-picks-submission-guidelines.md
+++ b/docs/how-does-daily-dev-work/community-picks-submission-guidelines.md
@@ -7,7 +7,7 @@ sidebar_label: "Community Picks Guidelines"
 ## What are Community Picks?
 Community Picks are articles that are scouted out and submitted by the community. These articles then appear in the daily.dev feed like any other article.
 
-Nearly any article, from nearly any website can be submitted as long as it is related to tech / development, and subequently can be enjoyed by the entire daily.dev community.
+Nearly any article, from nearly any website can be submitted as long as it is related to tech / development.
 
 To get access to this feature you first need to earn the Scout privilege (min. 250 reputation points). Only people with the Scout privilege can submit links and are limited to 3 submissions per day.
 


### PR DESCRIPTION
Temporary section so as not to block engineering requirements while we fix redirects. **to be removed later**