### PR TITLE
Fix build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
+          cache: 'yarn'
       - name: install dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
       - name: run build
-        run: npm run build
+        run: yarn build


### PR DESCRIPTION
This PR fixed the build workflow @eddiejaoude added in https://github.com/dailydotdev/docs/pull/125. The `npm ci` command doesn't work if no lock file is present, therefore you have to use the regular `install` command.

But there is a `yarn.lock` file, so the workflow file has been updated to use **yarn** instead. Added [caching for the dependencies](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data) too, not sure if it'll do much but hey.