### PR TITLE
 fix: DocSearch covered by nav because of z-index

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -140,7 +140,6 @@ html[data-theme='dark'] .DocSearch {
 
 .navbar {
   background-color:  #0e1217;
-  z-index: 9999;
 }
 
 html[data-theme='light'] .navbar {


### PR DESCRIPTION
Resolves #159

## Background 
The current issue with DocSearch modal being covered by nav bar arose as a side effect of the fix in #112 and #113.

In #112, an attempt was made to avoid the Youtube videos' "total time" to be floating on the top nav by making the nav's `z-index` to be `9999`. It did solve the issue but it caused #159 too. 

In #113 the issue was fully fixed by adjusting the z-index of the "total time" element itself, so the fix in #112 was no longer necessary.

Actually, the `z-index` for the top nav is already managed by `z-index: var(--ifm-z-index-fixed);` so manually specifying a value while not using CSS variables might easily break other styles.

## Screenshots 

Before | After
---|---
![docs daily dev_video-tutorials](https://user-images.githubusercontent.com/16297877/194792961-72a75879-ca7f-4da5-9bd8-e80a12f6fda4.png) | ![localhost_3000_video-tutorials](https://user-images.githubusercontent.com/16297877/194792960-c7e21315-6f0b-4570-8a9d-41e1b2fea747.png)

## Tests

Tested the following functionalities are working on the preview site:
https://docs-git-fork-gabrielkoo-fix-modal-covered-by-nav-dailydotdev.vercel.app/video-tutorials

- [x] DocSearch Modal is no longer blocked by top nav
- [x] Youtube video "total time" is not floating on top nav
