### PR TITLE
fix: replace webm video with working video

### DIFF
--- a/docs/key-features/search.md
+++ b/docs/key-features/search.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 <video loop autoPlay muted width="100%">
     <source src="https://daily-now-res.cloudinary.com/video/upload/s--ldicxh37--/v1694071721/search_daily_dev_dkqm25.mp4" type="video/mp4" />
-    <source src="https://daily-now-res.cloudinary.com/video/upload/s--wuDfV-fW--/v1694071721/search_daily_dev_dkqm25.webm" type="video/webm" />
+    <source src="https://daily-now-res.cloudinary.com/video/upload/v1695814691/search_daily_dev_dkqm25_jae0jq.webm" type="video/webm" />
 </video>
 
 ## What is daily.dev Search?

--- a/docs/key-features/search.md
+++ b/docs/key-features/search.md
@@ -5,8 +5,8 @@ sidebar_position: 2
 # Search
 
 <video loop autoPlay muted width="100%">
-    <source src="https://daily-now-res.cloudinary.com/video/upload/s--ldicxh37--/v1694071721/search_daily_dev_dkqm25.mp4" type="video/mp4" />
     <source src="https://daily-now-res.cloudinary.com/video/upload/v1695814691/search_daily_dev_dkqm25_jae0jq.webm" type="video/webm" />
+    <source src="https://daily-now-res.cloudinary.com/video/upload/s--ldicxh37--/v1694071721/search_daily_dev_dkqm25.mp4" type="video/mp4" />
 </video>
 
 ## What is daily.dev Search?


### PR DESCRIPTION
While working with onboarding, noticed that the order of the video sources are important. Moved webm to be higher than mp4.