### PR TITLE
fix: style community icon on mobile view

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -535,7 +535,12 @@ html[data-theme='light'] .menu__link:before {
 }
 .theme-doc-sidebar-menu li:nth-child(12) .menu__link:before {
   background: url('../img/menu/community.svg');
-  left: 0.75rem;
+}
+
+.theme-doc-sidebar-menu li:nth-child(12) .menu__link {
+  position: relative;
+  margin-left: 0rem;
+  padding-left: 2.3rem;
 }
 
 .theme-doc-sidebar-item-link-level-2 > .menu__link {


### PR DESCRIPTION
fixes #249

Tweaked in custom.css file theme-doc-sidebar-menu 12th child menu__link.

<img width="1512" alt="Screenshot 2023-10-18 at 11 05 36 PM" src="https://github.com/dailydotdev/docs/assets/90052329/b89b83fb-c7f7-441a-9f89-4e915302ecea">
<img width="364" alt="Screenshot 2023-10-18 at 11 04 42 PM" src="https://github.com/dailydotdev/docs/assets/90052329/7ba9ef56-f6b0-4c7c-85d0-a60065c4495d">
