### PR TITLE
feat: new page for public squads

### DIFF
--- a/docs/squads/creating-your-squad.md
+++ b/docs/squads/creating-your-squad.md
@@ -36,5 +36,14 @@ Creating a new Squad is simple and straightforward. Follow these steps to get st
 Remember, the most vibrant Squads are those with active participation. Encourage your members to contribute, share their knowledge, and engage in discussions. With your leadership and the tools provided by daily.dev, your Squad is well on its way to becoming a dynamic and valuable community for developers.
 :::
 
+## Squad Visibility (Private vs. Public)
+
+You can choose the visibility of your Squad:
+
+1. **Private Squads**: Only members can view and contribute to the Squad content. You control invitations.
+2. **Public Squads** (in closed beta): Everyone can see the content, and the posts may organically appear on the main feed. Read more about [how to become a Public Squad](/squads/public-squads.md). 
+
+By understanding and utilizing these tools and settings effectively, you can shape your Squad into a vibrant, engaging, and respectful community. 
+
 Congratulations! You've created your first Squad. In the following pages, you'll learn how to invite other developers, 
 manage posts and discussions, and use various admin and moderation tools to help your Squad thrive.

--- a/docs/squads/moderating-your-squad.md
+++ b/docs/squads/moderating-your-squad.md
@@ -2,7 +2,7 @@
 sidebar_position: 2
 ---
 
-# Managing Your Squad
+# Moderating Your Squad
 
 ## Admin, Moderation, and Privacy Settings
 
@@ -37,12 +37,3 @@ Your Squad members can have different roles, each with distinct permissions:
 
 * **Promoting to Moderator/Admin**: Find the member you wish to promote in the member list, select "Promote to Moderator" or "Make an Admin" from their options menu. They will now have access to moderation tools.
 * **Demoting Moderators**: If a moderator isn't fulfilling their duties, demote them back to a member by selecting "Demote to Member" in their options menu.
-
-## Squad Visibility (Private vs. Public)
-
-You can choose the visibility of your Squad:
-
-1. **Private Squads**: Only members can view and contribute to the Squad content. You control invitations.
-2. **Public Squads** (in closed beta): Open to all daily.dev users. Currently, public Squads are in early beta with a waitlist for public Squad creation.
-
-By understanding and utilizing these tools and settings effectively, you can shape your Squad into a vibrant, engaging, and respectful community. 

--- a/docs/squads/public-squads.md
+++ b/docs/squads/public-squads.md
@@ -1,0 +1,57 @@
+---
+sidebar_position: 3
+---
+
+# Becoming a Public Squad
+
+## Introduction to Public Squads
+
+Public Squads are the newest way to feature your content and gain organic exposure on daily.dev. Public Squads, like sources, receive exposure in the daily.dev feed, regardless of whether users have joined them or not. It offers an unparalleled growth opportunity for engagement and traffic within the daily.dev community. 
+
+## Distinctive Features of Public Squads
+
+Public Squads stand out in several ways:
+
+* **Organic exposure**: Gain visibility in the daily.dev feed, similar to how sources are featured.
+* **Gain followers**: Public Squads can accumulate followers, increasing engagement and reach.
+* **Direct interaction**: Engage directly with your audience, customizing posts to suit your community's preferences.
+* **Manual content uploads**: Unlike sources, Public Squads require manual post uploads, offering more control over shared content.
+
+## Benefits of Being Public
+
+* **Increased visibility**: Engaging content leads to more exposure as users interact and upvote.
+* **Community engagement**: Actively engage with your audience through discussions, questions, and any type of content you want to post.
+* **Get featured in the Public Squads Directory**: Stand out in the daily.dev community by being featured in the [Public Squads Directory](https://app.daily.dev/squads), a go-to place for members to discover new and interesting Squads. Read more about it below. 
+
+## How to Become a Public Squad
+
+1. **Start your Squad**: [Create a Squad](https://app.daily.dev/squads/new) with a clear theme or focus.
+2. **Post your content**: Post at least three representative posts that align with your Squad's ongoing content style.
+3. **Apply for review**: Submit your Squad for review. Once your Squad passes the review process it will automatically become Public. Currently we accept applications via email at advocacy@daily.dev
+
+:::tip
+### How to increase your chances to pass the review process?
+
+1. Active engagement. Squads with existing members and active participation are more likely to get approved.
+2. Effective Squad presentation. Craft a compelling Squad name, description, and image that clearly represent its purpose.
+3. Focus on content quality. Make sure that the posts you have on your Squad represent the highest quality of what you have to offer to your community. don't hesitate to go beyond the minimum post requirement to help our team assess your content. 
+4. Comply with our [content guidelines](../for-content-creators/content-guidelines.md).
+:::
+
+:::caution
+Public Squad status is revocable. Non-compliance with guidelines or misuse of the platform can lead to a loss of public status. Exercise this privilege with responsibility.
+:::
+
+## Getting Featured on the Public Squads Directory
+
+The Public Squads Directory on daily.dev is a curated space where community members discover new and engaging Public Squads. Being featured here significantly enhances your Squad's visibility and traffic.
+
+### How to get featured on the directory?
+
+The selection of Public Squads to be featured in the directory is an editorial decision made by our team. This process ensures that only the most engaging, valuable, and compliant Squads are highlighted.
+
+Here are a few thing syou can do to increase your chances of being featured:
+
+1. **Consistently post exceptional content**: High-quality content is the primary criteria for being featured.
+2. **Foster a thriving community**: Active engagement and a growing member base can influence your Squad's inclusion in the directory.
+3. **Create impactful interactions**: Regular posts and discussions that resonate with your audience can elevate your Squad's appeal.

--- a/src/components/homepage/homeNavBoxes.js
+++ b/src/components/homepage/homeNavBoxes.js
@@ -53,7 +53,8 @@ const FeatureList = [
     items: [
       {url: "docs/squads/creating-your-squad", text: "Creating Your Squad"},
       {url: "docs/squads/growing-your-squad", text: "Growing Your Squad"},
-      {url: "docs/squads/managing-your-squad", text: "Managing Your Squad"},
+      {url: "docs/squads/moderating-your-squad", text: "Moderating Your Squad"},
+      {url: "docs/squads/public-squads", text: "Becoming a Public Squad"},
     ]
   },
   {


### PR DESCRIPTION
- created a new page for public squads
- renamed "managing your squad" to "moderating your squad" for more clarity
- updated the "create your squad page with some content that was originally under "managing your squad"
- minor edits and language improvements 