### PR TITLE
Key updates to public squads following the latest release

### DIFF
--- a/docs/squads/public-squads.md
+++ b/docs/squads/public-squads.md
@@ -23,13 +23,14 @@ Public Squads stand out in several ways:
 
 * **Increased visibility**: Engaging content leads to more exposure as users interact and upvote.
 * **Community engagement**: Actively engage with your audience through discussions, questions, and any type of content you want to post.
+* **Special recognition**: Public Squads receive a special "Public Squad" badge on the top of the Squad page. The admin and moderators are featured at the header of the Squad, and the Squad's key stats (total views, total upvotes, and number of posts) are displayed at the top. This helps gain credibility in front of potential new squad members who are considering whether to join.
 * **Apply to get featured in the Public Squads Directory**: Public Squads are also elgible to apply to get featured on the the [Public Squads Directory](https://app.daily.dev/squads), a go-to place for the daily.dev community to discover new and interesting Squads. Read more about how you can get featured below. 
 
 ## How to become a Public Squad
 
 1. **Start your Squad**: [Create a Squad](https://app.daily.dev/squads/new) with a clear theme or focus.
-2. **Post your content**: Post at least three representative posts that align with your Squad's ongoing content style.
-3. **Apply for review**: Submit your Squad for review. Once your Squad passes the review process it will automatically become Public. Currently we accept applications via this [online form](https://it057218.typeform.com/Publicsquads).
+2. **Post your content**: Post at least five representative posts that align with your Squad's ongoing content style.
+3. **Apply for review**: Submit your Squad for review within the app. Once your Squad passes the review process, it will automatically become Public.
 
 :::tip
 ### How to increase your chances to pass the review process?


### PR DESCRIPTION
- It take now 5 posts instead of three to apply for public status
- Added some new benefits of being public