### PR TITLE
feat: use real-time devcard example

### DIFF
--- a/docs/your-profile/reading-streak.md
+++ b/docs/your-profile/reading-streak.md
@@ -64,7 +64,7 @@ Your longest streak and total reading days are featured on your profile, showcas
 
 Your longest streak is displayed on your profile and your [DevCard](https://app.daily.dev/devcard), allowing you to showcase your dedication. Check out a sample below 👇#notsohumblebrag
 
-![DevCard Integration](https://daily-now-res.cloudinary.com/image/upload/v1719905253/docs/content_b4284768-370f-45f0-ad18-b94699badcee.webp)
+![DevCard Integration](https://raw.githubusercontent.com/omBratteng/omBratteng/devcard/devcard-background.webp)
 
 ## Public Leaderboard
 


### PR DESCRIPTION
My github profile repository now contains an always up to date devcard with nice background. So we can use it in the docs, so it's always fresh 🤓 

![image](https://github.com/dailydotdev/docs/assets/1681525/8a78063a-0a8e-4388-8062-88358d262ceb)
