### PR TITLE
docs: update content contribution methods and sunset Community Picks

### DIFF
--- a/docs/for-content-creators/how-to-get-featured.md
+++ b/docs/for-content-creators/how-to-get-featured.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 0
-description: "Learn how to feature your content on daily.dev through Squads, Source Suggestions, and Community Picks to reach a global developer audience."
+description: "Learn how to feature your content on daily.dev through Squads, Source Suggestions, and Direct Posting to reach a global developer audience."
 ---
 
 # How to Get Featured on daily.dev
@@ -15,7 +15,7 @@ There are three primary ways to have your content featured on daily.dev:
 
 1. **Start a Squad**: A Squad is a group where you and other developers can come together around your content on daily.dev. Think of Squads as developer-specific online groups where you can publish content, share with the community, and build a following.
 2. **Suggest a Source**: daily.dev collects posts from various unique sources across the web. All sources are added based on community requests, reflecting our community-driven approach.
-3. **Community Picks**: Community Picks are posts shared by the community. You can submit links from nearly any website, providing valuable content from sources beyond our pre-qualified list.
+3. **Direct Posting**: You can now contribute content directly by clicking "New Post" anywhere on daily.dev. This replaced the previous Community Picks system, making content contribution simpler and more direct.
 
 ## Eligibility and Ideal Users for Each Method
 
@@ -23,7 +23,7 @@ There are three primary ways to have your content featured on daily.dev:
 |--------------------|------------------------------------------------------------------------------------------------------------|------------------------------------------------|
 | **Squads**         | Open to all daily.dev users.                                                                               | Individual developers, content creators, and companies looking to build a community and followership. |
 | **Sources**        | Must own a well-known publication or developer blogging platform. Corporate and personal blogs are excluded. | Owners of established publications or platforms in the developer community, excluding corporate and personal blogs. |
-| **Community Picks** | Available to all daily.dev users.                                                                          | Any daily.dev user with more than 250 reputation points, ideal for sharing valuable content with the community, regardless of authorship. |
+| **Direct Posting** | Open to all daily.dev users.                                                                               | Any daily.dev user looking to share their own content or valuable content they've discovered, with direct attribution and increased visibility. |
 
 :::note
 Remember, all featured content must adhere to our [content guidelines](/for-content-creators/content-guidelines.md) regardless of the submission method.
@@ -43,14 +43,14 @@ If you’re the owner of a prominent publication or a developer-focused blogging
 
 → [Learn more about suggesting a source](/for-content-creators/suggest-new-source.md)
 
-### 3. Community Picks
+### 3. Direct Posting
 
-Community Picks on daily.dev is open to all users, offering a democratic way to share and promote content. Whether you're the author or simply a fan of great content, you can submit individual links for the community to discover. This feature is particularly useful for showcasing valuable content that might otherwise go unnoticed. Although Community Picks is set to be phased out, it currently serves as a key tool for content discovery.
+Direct posting on daily.dev is open to all users, offering a simple way to share and promote content directly. Simply click "New Post" anywhere on the platform to contribute your content. This system replaced Community Picks in 2025, making content contribution more streamlined while giving contributors more credit and visibility. Your content is attributed directly to your profile, helping you build your following and reputation.
 
-→ [Learn more about Community Picks](../key-features/community-picks.md)
+→ [Learn more about the transition from Community Picks](../key-features/community-picks.md)
 
 ## Wrap Up
 
-Getting your content featured on daily.dev is a straightforward process. Each method - Starting a Squad, Submitting a Source, or using Community Picks - serves different goals and needs. Choose the method that aligns best with your content strategy and audience.
+Getting your content featured on daily.dev is a straightforward process. Each method - Starting a Squad, Submitting a Source, or Direct Posting - serves different goals and needs. Choose the method that aligns best with your content strategy and audience.
 
 Adhering to our content guidelines is crucial to ensure a positive, constructive environment for all daily.dev members. By following these steps, you can effectively showcase your content and engage with a dynamic community of developers and tech enthusiasts.

--- a/docs/key-features/community-picks.md
+++ b/docs/key-features/community-picks.md
@@ -1,106 +1,54 @@
 ---
 sidebar_position: 9
-description: "Discover how to submit Community Picks on daily.dev to share impactful content that supports the tech journey of the developer community."
+description: "Learn about Community Picks on daily.dev and how content contribution has evolved with the new direct posting feature."
 ---
 
-# Community Picks
+# Community Picks - Sunset Notice
 
-Community Picks are posts that are sourced by the community. 
-
-We want you to submit posts that made a real difference to your tech journey. Whether these are in-depth tutorials, interesting perspectives on tech problems, or well thought out and high-effort entertainment pieces aimed at developers. Above all, we want posts that you believe need more exposure, from creators you admire, that you think will benefit the daily.dev developer community. 
-
-:::caution
-Before you embark on submitting your Community Picks, it's crucial to familiarize yourself with our [content guidelines](../for-content-creators/content-guidelines.md). These principles are the cornerstone of our content review process and they ensure that our platform maintains its standard of high-quality, relevant, and ethical content. So, take a moment to read through these guidelines thoroughly. Doing so will increase your understanding of what we look for and improve the likelihood of your content being accepted. Your informed contribution can help make our platform an even more enriching resource for our community.
-:::
-
-## Quick Overview Video
+![Sunsetting Community Picks](https://daily-now-res.cloudinary.com/image/upload/v1753370633/docs/Sunsetting_community_picks.jpg)
 
 :::info
-To get access to this feature you first need to earn the Scout privilege (min. 250 reputation points). Only people with the Scout privilege can submit links and are limited to 5 submissions per day. Learn more about [how to gain reputation points](../your-profile/reputation.md)
+**Community Picks has been sunset** as of 2025. We've simplified content contribution - anyone can now click **"New Post"** and contribute directly to daily.dev.
 :::
 
-<iframe width="700" height="400"  src="https://www.youtube-nocookie.com/embed/JlBlTIMfrGM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+## What Were Community Picks?
 
-## Community Picks in the daily.dev feed
+Community Picks were posts sourced by the community - one of daily.dev's most successful features that allowed developers to directly contribute content they believed in. It was our first real experiment in community involvement, and it became our top content source by every metric that matters.
 
-Community Picks are posts that are added to the daily.dev feed by our community members. These posts can be from nearly any website / online publication, not just from our pre-qualified sources.
+## What's Changed?
 
-### How can I spot a community pick?
-On a card in the feed there is always an icon showing the source in the top left.
+Instead of the separate Community Picks mechanism, **anyone can now click "New Post" and contribute directly**. No extra steps, no abstraction - just direct contribution to the platform.
 
-![screenshot showing the community picks icon on the top left of a card](https://daily-now-res.cloudinary.com/image/upload/v1724397565/docs-v2/f531e2b3-a052-44d2-8bac-311df72e906d.png)
+### Benefits of the New System
 
-Clicking on this icon will take you to the community picks feed.
+- **More credit for your work** - contributions live under your name
+- **Better visibility** for your profile
+- **Faster path** to grow your following
+- **Direct connection** between contributors and content consumers
 
-### Community Picks feed
-All of the posts submitted by the community are available in the [Community Picks feed.](https://app.daily.dev/sources/community)
+## Your Previous Community Picks
 
-![community picks page](https://daily-now-res.cloudinary.com/image/upload/v1724397631/docs-v2/03d6da9c-7a30-44aa-9d7d-96e345b5df36.png)
+All content you previously shared through Community Picks is still available on the platform. Simply visit your profile and check the **Posts tab** to see all your contributions.
 
+## How to Contribute Content Now
 
-## Submitting / Scouting a Community Pick
-We want you to submit posts that made a real difference to your tech journey. Whether they are in-depth tutorials, interesting perspectives on tech problems, or well thought out and high effort entertainment pieces aimed at developers.
+With the new system, contributing content is simpler than ever:
 
-Above all, we want posts that you believe need more exposure, from authors you admire, that you believe will benefit the daily.dev developer community.
+![New Post Button](https://daily-now-res.cloudinary.com/image/upload/v1753370632/docs/cpimage.png)
 
-Low effort, poor quality and (self) promotional content will be removed to ensure a high standard on the platform.
+1. **Click "New Post"** anywhere on daily.dev
+2. **Share your content directly** - no separate submission process needed
+3. **Build your following** - content is attributed directly to you
+4. **Get more exposure** - higher reputation users get increased visibility
 
-:::info
-Before submitting a Community Pick, you should read the [**content guidelines**](../for-content-creators/content-guidelines.md) to ensure your post is suitable for the feed.
-:::
+### Content Guidelines
 
-### Reputation Requirements
-To be able to submit a Community Pick you need to have at least 250 reputation on daily.dev. Once you reach this threshold you will earn the Scout privilege.
+Before contributing any content, make sure to familiarize yourself with our [content guidelines](../for-content-creators/content-guidelines.md). These ensure our platform maintains high-quality, relevant, and ethical content standards.
 
-:::tip
-[Learn how to gain reputation](../your-profile/reputation.md) and how reputation works.
-:::
+## Following Individual Contributors
 
-If you do not have enough reputation to submit a link you will see a message telling you that you do not have enough reputation and the submit button will be disabled.
+Instead of subscribing to Community Picks as a general source, you can now **follow individual contributors** whose content you enjoy. This creates a more personal and precise discovery experience.
 
-![not enough reputation for community links notification](https://github.com/user-attachments/assets/8a132a66-b4f5-4def-b314-a3f6dd999819)
+## Thank You to Community Picks Contributors
 
-
-### How to submit a link
-On the menu on the left you will see a section "Contribute" containing a button "Submit link".
-
-Clicking on that button will open the "Submit link" modal.
-
-This is how the modal looks like
-
-![Submit modal example](https://daily-now-res.cloudinary.com/image/upload/v1724397819/docs-v2/e8d2da79-6da6-47b8-9b1a-d974f512df6b.png)
-
-Here you can paste in the post URL and then press submit.
-
-You will then see either a success, already exists or error message.
-
-:::caution
-Please note that **submitting your own articles is not allowed.** Please share amazing articles from other authors that you have enjoyed. If you're looking for ways to post your own content please refer to our ["How to get featured?"](../for-content-creators/how-to-get-featured.md) guide.
-:::
-
-#### Post already exists
-If the post already exists in the daily.dev feed you will see a message explaining the post already exists and a link to that post.
-
-### Successful Submissions
-If the post you submitted has a valid URL and doesn't already exist you will get a confirmation that you will be notified by an in-app notification and an email about the request status.
-
-### Rejection Scenarios
-There are multiple reasons why a submission to Community Picks could fail.
-
-#### Before submission
-| Message | Notes |
-| --- | --- |
-| You do not have sufficient permissions and or reputation to submit a link to Community Picks yet. | You need 250 reputation and to have not received a ban from posting Community Picks in order to be able to submit a link |
-| You can only submit 3 links per day and have reached your limit. Please try again tomorrow. | None |
-| The URL you submitted is not valid, please check and try again. | Please include the full url including "https://" etc. when submitting a link |
-| This post has previously appeared in the daily.dev feed but was deleted and cannot be added to the feed again. | We may delete posts that do not meet our content guidelines. Once a post has been deleted it cannot be added to the daily.dev feed again |
-
-#### After submission (via email)
-| Failure reason | Notes |
-| --- | --- |
-| We ran into a problem adding this post, our team is looking into it. | This is a generic fallback which normally displays when our crawler could not extract some key information such as the title of the post | 
-| This post is already on daily.dev! | If you manage to submit a post at the same time as someone else it may be possible that the post will exist once we come to process it and so you will receive this message |
-| The post you submitted is written by an author who violated our community guidelines and is banned. We no longer accept submissions from this author. | It is rare we ban authors, but occasionally they consistently post spammy or NSFW content that is not suitable for daily.dev. We will not accept any posts written by these authors. |
-| You can’t submit your own posts as community picks, please suggest posts by other people. | Community Picks are not designed for self promotion, instead try submitting posts written by others that you think will benefit the community. |
-| The post you submitted is behind a paywall, so we cannot add it to the daily.dev feed. | We try our best to make sure all posts shared are free for the community. If we detect a paywall then a post will not be accepted for the feed. |
-| There was an error and we were unable to gather the required information from the URL submitted to add it to our feed. | If a site has an unusual structure our crawler may not be able to parse the page correctly to create the tags and TLDR. |
+Community Picks wasn't just a feature - it was the foundation that proved community-driven content could thrive on daily.dev. Thank you to everyone who contributed. Your work helped shape what daily.dev is today, and your contributions continue to live on under your profile.

--- a/docs/setting-up-your-feed/advanced-filtering-options.md
+++ b/docs/setting-up-your-feed/advanced-filtering-options.md
@@ -33,7 +33,7 @@ Once in the menu, you’ll find several on/off toggle switches that let you fine
 
 | Category            | Description                                                                                                                                                                                                                                   |
 |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Community Picks     | Community-sourced posts that are often high-quality or entertaining. [Learn more](/docs/key-features/community-picks)                                                                                   |
+| Community Picks     | Community-contributed content (Note: Community Picks mechanism was sunset in 2025 - content is now contributed directly via "New Post"). [Learn more](../key-features/community-picks.md)                |
 | Comparisons         | Posts comparing libraries or tools to aid decision-making.                                                                                                                                             |
 | Listicles           | Posts containing lists, such as "10 best libraries for X" or "5 ways to improve Y".                                                                                                                    |
 | Memes               | Humorous posts or memes.                                                                                                                                                                               |

--- a/docs/your-profile/reputation.md
+++ b/docs/your-profile/reputation.md
@@ -64,7 +64,7 @@ Reputation growth brings special privileges:
 |----------------------|------------|  
 | 250+                 | Upvotes contribute to others' reputation |  
 | 250+                 | Can [suggest new sources](../for-content-creators/suggest-new-source.md) for the feed |  
-| 250+                 | Eligible to submit links via [Community Picks](../key-features/community-picks.md) |  
+| 250+                 | Can contribute content directly via "New Post" (Community Picks was sunset in 2025) |  
 | Various Points       | Unlock exclusive themes for your [DevCard](/your-profile/devcard.md) |  
 | More Reputation      | Increases your content’s reach and visibility on daily.dev |  
 

--- a/src/components/homepage/homeNavBoxes.js
+++ b/src/components/homepage/homeNavBoxes.js
@@ -44,7 +44,7 @@ const FeatureList = [
       { url: 'docs/key-features/search', text: 'Search' },
       { url: 'docs/key-features/pause-new-tab', text: 'Pause New Tab (DND)' },
       { url: 'docs/key-features/the-companion', text: 'Companion Widget' },
-      { url: 'docs/key-features/community-picks', text: 'Community Picks' },
+      { url: 'docs/key-features/community-picks', text: 'Community Picks (Sunset)' },
     ],
   },
   {


### PR DESCRIPTION
- Revised the "How to Get Featured" guide to reflect the transition from Community Picks to Direct Posting.
- Updated the Community Picks documentation to announce its sunset in 2025 and explain the new direct contribution process.
- Adjusted references to Community Picks in various documents to clarify the changes in content submission methods.