### PR TITLE
docs: add Stack & Tools documentation

### DIFF
--- a/docs/squads/creating-your-squad.md
+++ b/docs/squads/creating-your-squad.md
@@ -52,4 +52,17 @@ When creating a Squad, select the desired visibility:
 
 Public Squads must select a category during setup. Categories like Web, Mobile, AI, and Fun help users discover Squads that align with their interests.
 
+## Squad Stack & Tools
+
+Squads can showcase the technologies, frameworks, and tools that are central to the community. This helps potential members quickly understand what technologies the Squad focuses on.
+
+Squad admins can manage the Squad's stack from the Squad settings:
+
+1. Go to your **Squad page**
+2. Open **Squad settings**
+3. Find the **Stack & Tools** section
+4. Add technologies relevant to your Squad's focus
+
+For example, a React Squad might add React, TypeScript, and Next.js to their stack, while a DevOps Squad might showcase Kubernetes, Terraform, and AWS.
+
 For additional guidance, see our Squad moderation documentation.

--- a/docs/your-profile/stack-and-tools.md
+++ b/docs/your-profile/stack-and-tools.md
@@ -63,11 +63,3 @@ You can add up to **100 items** to your stack. This gives you plenty of room to 
 Your Stack & Tools section is visible on your public profile. Anyone visiting your profile can see the technologies you've added, organized by section.
 
 If you haven't added any items yet, the section won't appear to visitors — only you'll see the prompt to add your first item.
-
-## Squad Stacks
-
-Squads can also showcase their central technologies using Stack & Tools. This helps potential members understand what technologies are core to the Squad's focus and discussions.
-
-Squad admins can manage the Squad's stack from the Squad settings, using the same interface as personal stacks.
-
-[Learn more about Squads →](../squads/creating-your-squad.md)

--- a/docs/your-profile/stack-and-tools.md
+++ b/docs/your-profile/stack-and-tools.md
@@ -1,0 +1,71 @@
+---
+sidebar_position: 2
+description: "Showcase your tech stack on daily.dev — the programming languages, frameworks, tools, and technologies you use. Build your developer identity and help others discover your expertise."
+---
+
+# Stack & Tools
+
+{/* TODO: Add screenshot of Stack & Tools section on profile */}
+
+Your Stack & Tools section lets you showcase the technologies, frameworks, languages, and tools you work with. It's a quick way for other developers to understand your technical background and expertise.
+
+## Why Add Your Stack?
+
+- **Build your developer identity** — Show what technologies define your work
+- **Help others find you** — Developers with similar stacks can discover and connect with you
+- **Improve Career Mode matching** — Your stack helps us match you with relevant [job opportunities](../career-mode/overview.md)
+- **Share your journey** — Track when you started using each technology
+
+## Adding Items to Your Stack
+
+1. Go to your **profile page**
+2. Find the **Stack & Tools** section
+3. Click the **Add** button
+4. Start typing the name of a technology, tool, or skill
+5. Select from suggestions or add a custom entry
+6. Choose a **section** to organize it
+7. Optionally set **Using since** to show how long you've been using it
+8. Click **Add to stack**
+
+:::tip
+As you type, you'll see suggestions from our database of known tools and technologies. Selecting a suggestion adds the official icon automatically.
+:::
+
+## Sections
+
+Organize your stack into sections that reflect how you use each technology:
+
+| Section | Use for |
+|---------|---------|
+| **Primary** | Your main, day-to-day technologies |
+| **Hobby** | Technologies you use for personal projects |
+| **Learning** | Technologies you're currently learning |
+| **Past** | Technologies you've used before but moved on from |
+| **Custom** | Create your own section name |
+
+## Editing and Removing Items
+
+Hover over any stack item to reveal edit and delete options:
+
+- **Edit** — Change the section or "Using since" date
+- **Delete** — Remove the item from your stack
+
+:::note
+The technology name cannot be edited after adding. To change it, delete the item and add it again with the correct name.
+:::
+
+## Limits
+
+You can add up to **100 items** to your stack. This gives you plenty of room to showcase your full technical breadth while keeping profiles focused and meaningful.
+
+## Visibility
+
+Your Stack & Tools section is visible on your public profile. Anyone visiting your profile can see the technologies you've added, organized by section.
+
+If you haven't added any items yet, the section won't appear to visitors — only you'll see the prompt to add your first item.
+
+## Stack and Career Mode
+
+Your stack plays a role in [Career Mode](../career-mode/overview.md) matching. When you enable Career Mode, the technologies in your stack help us understand your skills and match you with relevant opportunities.
+
+[Learn more about how matching works →](../career-mode/how-matching-works.md)

--- a/docs/your-profile/stack-and-tools.md
+++ b/docs/your-profile/stack-and-tools.md
@@ -7,13 +7,13 @@ description: "Showcase your tech stack on daily.dev — the programming language
 
 {/* TODO: Add screenshot of Stack & Tools section on profile */}
 
-Your Stack & Tools section lets you showcase the technologies, frameworks, languages, and tools you work with. It's a quick way for other developers to understand your technical background and expertise.
+Your Stack & Tools section lets you showcase the technologies, frameworks, languages, and tools you work with. It's a quick way for other developers — and potential employers — to understand your technical background and expertise.
 
 ## Why Add Your Stack?
 
 - **Build your developer identity** — Show what technologies define your work
 - **Help others find you** — Developers with similar stacks can discover and connect with you
-- **Improve Career Mode matching** — Your stack helps us match you with relevant [job opportunities](../career-mode/overview.md)
+- **Stand out to recruiters** — When recruiters view your profile through [Career Mode](../career-mode/overview.md), your stack helps them quickly understand your technical expertise
 - **Share your journey** — Track when you started using each technology
 
 ## Adding Items to Your Stack
@@ -64,8 +64,10 @@ Your Stack & Tools section is visible on your public profile. Anyone visiting yo
 
 If you haven't added any items yet, the section won't appear to visitors — only you'll see the prompt to add your first item.
 
-## Stack and Career Mode
+## Squad Stacks
 
-Your stack plays a role in [Career Mode](../career-mode/overview.md) matching. When you enable Career Mode, the technologies in your stack help us understand your skills and match you with relevant opportunities.
+Squads can also showcase their central technologies using Stack & Tools. This helps potential members understand what technologies are core to the Squad's focus and discussions.
 
-[Learn more about how matching works →](../career-mode/how-matching-works.md)
+Squad admins can manage the Squad's stack from the Squad settings, using the same interface as personal stacks.
+
+[Learn more about Squads →](../squads/creating-your-squad.md)

--- a/src/components/homepage/homeNavBoxes.js
+++ b/src/components/homepage/homeNavBoxes.js
@@ -61,6 +61,7 @@ const FeatureList = [
         text: 'Company verified badge',
       },
       { url: 'docs/your-profile/top-readers', text: 'Top readers' },
+      { url: 'docs/your-profile/stack-and-tools', text: 'Stack & Tools' },
       { url: 'docs/your-profile/devcard', text: 'DevCard' },
       { url: 'docs/your-profile/account-details', text: 'Account settings' },
       {

--- a/src/components/homepage/homeNavBoxes.module.css
+++ b/src/components/homepage/homeNavBoxes.module.css
@@ -88,7 +88,7 @@
 .homecard {
   background-color: #1c1f26;
   width: 330px;
-  height: 470px;
+  height: 510px;
   padding: 20px;
   position: relative;
   display: block;


### PR DESCRIPTION
## Summary

Adds documentation for the **Stack & Tools** profile feature, which was missing from the docs.

## What's documented

- What the feature is and why developers should use it
- How to add items (with autocomplete suggestions)
- Available sections: Primary, Hobby, Learning, Past, Custom
- Editing and removing items
- The 100 item limit
- How it connects to Career Mode matching

## What's NOT documented (because not yet available in UI)

- Reordering items (API supports it, UI doesn't expose it yet)
- Custom icons (API supports it, UI doesn't expose it yet)

## TODO

- [ ] Add screenshot of the Stack & Tools section on a profile
- [ ] Add screenshot of the add/edit modal

## Related

This addresses a documentation gap identified while auditing docs against the daily-api and apps repos.