### PR TITLE
docs: add Happening Now, Quests, Skills, and Squad analytics

### DIFF
--- a/docs/key-features/happening-now.md
+++ b/docs/key-features/happening-now.md
@@ -1,0 +1,70 @@
+---
+sidebar_position: 11
+description:
+  'Happening Now is a curated hub of the most important developer stories, releases, and discussions
+  in real time. Learn how to browse channels, expand TL;DRs, and subscribe to digests on daily.dev.'
+---
+
+# Happening Now
+
+**Happening Now** is your home for what's moving in the developer world right now. Instead of
+scrolling a long feed, you get a tight list of the most important stories, releases, and
+discussions, each with a short headline you can expand for a TL;DR.
+
+You can find Happening Now in the left sidebar, at
+[https://app.daily.dev/highlights](https://app.daily.dev/highlights), or as cards inside your main
+feed.
+
+## Browsing highlights
+
+Open Happening Now and you'll see two kinds of tabs:
+
+- **Headlines** – the cross-topic feed of the biggest stories happening across the developer
+  ecosystem.
+- **Channel tabs** – curated topic lanes (for example, AI tools, frameworks, or releases). Each
+  channel has its own URL at `/highlights/{channel}` so you can bookmark or share it.
+
+Each row in the list is a single highlight:
+
+- A short **headline** describing what happened.
+- A **timestamp** showing how recent it is.
+- An expandable **TL;DR** that summarizes the underlying article or discussion.
+- A **Read more** link that takes you to the full post and discussion on daily.dev.
+
+:::tip
+Channels are curated by daily.dev, so the tabs you see reflect topics the community is actively
+discussing. The list updates as new stories break.
+:::
+
+## Channel digests
+
+Some channels offer a periodic **digest**. When a digest is available, you'll see a banner at the
+top of that channel inviting you to subscribe. Subscribing turns on notifications so you get a
+recap of the channel's biggest stories on a regular cadence (for example, daily or weekly).
+
+You can manage which digests you receive from your
+[Notification Settings](/docs/your-profile/notification-settings-and-preferences).
+
+## Where else highlights show up
+
+Happening Now is more than a single page. The same curated content appears across daily.dev to keep
+you in the loop wherever you are:
+
+- **Main feed** – Highlights cards appear inline in your feed so you can catch breaking stories
+  while browsing.
+- **Post pages** – a rotating widget on the right side of post pages surfaces the latest major
+  headlines from the last 24 hours.
+- **Mobile and desktop** – the same experience works across devices, with swipe and keyboard
+  navigation between highlights when you open a post.
+
+## Why Happening Now
+
+The standard daily.dev feed is great for personalized, evergreen reading. Happening Now is
+different: it's optimized for time-sensitive context. Use it when you want to:
+
+- Catch up on the day's biggest releases without reading every post.
+- Track a single topic (a channel) closely without polluting your main feed.
+- Share a quick summary with your team via the dedicated highlight URL.
+
+Pair Happening Now with your [personalized feed](/docs/key-features/feeds) for a complete picture:
+the feed for depth, Happening Now for what just landed.

--- a/docs/plus/public-api.md
+++ b/docs/plus/public-api.md
@@ -186,11 +186,22 @@ All responses use JSON with a consistent structure.
 
 **Pagination:** Use cursor-based pagination by passing the `endCursor` value as the `cursor` parameter in subsequent requests.
 
-## AI Agent Integrations
+## Skills (AI Agent Integrations)
+
+The daily.dev plugin ships a set of **Skills** for your AI coding agent. Once you install the plugin in Claude Code, Cursor, Codex, or OpenClaw, the following skills are available:
+
+- **`/daily.dev`** – interact with your personalized feed, bookmarks, custom feeds, and profile through the Public API. Useful for pulling your reading list into your editor, saving links, or running your own custom feeds.
+- **`/daily-dev-ask`** – WebSearch for developers, grounded in daily.dev's community-curated articles. Ask a technical question and the agent searches the corpus of articles read and upvoted by the daily.dev community, then returns an answer with linked sources. Try it on the dedicated page at [https://app.daily.dev/agents/ask](https://app.daily.dev/agents/ask).
+
+Both skills require an active [Plus subscription](https://app.daily.dev/plus) and a Personal Access Token (see [Getting Started](#getting-started) above).
+
+:::info Why daily-dev-ask vs. generic web search?
+`daily-dev-ask` ranks results by developer upvotes (not SEO), restricts answers to community-vetted developer articles, and always grounds responses with links you can open. It's designed as a focused alternative to general web search when you want trustworthy, technical answers.
+:::
 
 ### Claude Code
 
-Add daily.dev to Claude Code as a plugin with these commands:
+Add the daily.dev plugin to Claude Code:
 
 ```bash
 claude plugin marketplace add https://github.com/dailydotdev/daily.git
@@ -198,27 +209,38 @@ claude plugin install daily.dev@daily.dev
 claude "/daily.dev setup"
 ```
 
-After installation, use the `/daily.dev` skill to interact with your daily.dev feed and other features.
+After installation you can invoke either skill from your prompt:
+
+- `/daily.dev` – interact with your feed, bookmarks, and custom feeds.
+- `/daily-dev-ask your question here` – search daily.dev's article corpus and get a sourced answer.
 
 ### OpenClaw
 
-Copy this instruction to your agent to get started:
+Copy one of these instructions to your agent to install the matching skill:
 
 ```
 Install the daily-dev skill from clawdhub and explain my new superpowers
 ```
 
-The skill is available on ClawHub at [https://clawhub.ai/idoshamun/daily-dev](https://clawhub.ai/idoshamun/daily-dev)
+```
+Install daily-dev-ask from clawhub and ask about my topic
+```
+
+The skills are available on ClawHub at [https://clawhub.ai/idoshamun/daily-dev](https://clawhub.ai/idoshamun/daily-dev).
 
 ### Codex
 
-Install the daily.dev skill in Codex with this command:
+Install the skills in Codex:
 
 ```
 $skill-installer install the daily.dev skill from https://github.com/dailydotdev/daily.git
 ```
 
-Restart Codex after installation, then use `$daily.dev` to interact with your feed.
+```
+$skill-installer install the daily-dev-ask skill from https://github.com/dailydotdev/daily.git
+```
+
+Restart Codex after installation, then use `$daily.dev` to interact with your feed or `$daily-dev-ask` to search daily.dev's article corpus.
 
 ### Cursor
 
@@ -228,7 +250,7 @@ Add daily.dev as a remote rule in Cursor:
 2. Click "Add Rule" → "Remote Rule (Github)"
 3. Enter the repository URL: `https://github.com/dailydotdev/daily.git`
 
-Use `/daily.dev` in Agent chat to interact with your feed.
+In Agent chat, use `/daily.dev` to interact with your feed or `/daily-dev-ask` to search daily.dev's article corpus.
 
 ### Direct API Integration
 

--- a/docs/squads/growing-your-squad.md
+++ b/docs/squads/growing-your-squad.md
@@ -86,6 +86,31 @@ To improve your chances of being featured in the directory:
 2. **Grow Membership**: Invite members to join and participate actively.
 3. **Post Consistently**: Regular high-quality posts boost engagement and visibility.
 
+## Squad analytics
+
+Every Public Squad page now includes an at-a-glance scoreboard so admins, moderators, and members can see how the community is performing without leaving the Squad.
+
+### Header stats
+
+The Squad header displays four headline metrics:
+
+- **Posts** – the total number of posts published in the Squad.
+- **Views** – how many times posts in the Squad have been viewed.
+- **Upvotes** – the total upvotes received across all posts.
+- **Awards** – the total awards given to the Squad. Click the count to open the full list of awards.
+
+These numbers update as your community engages with content, making it easy to track momentum over time.
+
+### Top members
+
+Just below the stats, the Squad header surfaces a **Top members** list of the Squad's most active contributors over the last 30 days. Click any avatar to view that member's profile, or open the full list to see everyone ranked.
+
+Top members are visible on Public Squads. If your Squad is private, the list is not shown.
+
+:::tip
+For a deeper view that includes impressions, upvote ratio, comments, bookmarks, shares, and clicks, open the dedicated [Squad analytics page](/docs/your-profile/post-and-squad-analytics) at `/squads/[handle]/analytics`. This view is available to admins and moderators with analytics access.
+:::
+
 ## Accelerate Growth with Boost
 
 Ready to fast-track your Squad's growth? **Boost** gives admins and moderators powerful tools to

--- a/docs/your-profile/quests.md
+++ b/docs/your-profile/quests.md
@@ -1,0 +1,90 @@
+---
+sidebar_position: 10
+description:
+  'Quests are short, tracked objectives on daily.dev that reward you with XP, Reputation, and
+  Cores. Learn how daily, weekly, and milestone quests work, how rotations refresh, and where to
+  claim your rewards in the Game Center.'
+---
+
+# Quests
+
+**Quests** are short, tracked objectives that turn everyday daily.dev activity into XP,
+[Reputation](/docs/your-profile/reputation), and [Cores](/docs/monetization/cores). They give you a
+clear set of next steps, refresh on a regular schedule, and roll up into your overall progress in
+the **Game Center**.
+
+## Where to find quests
+
+Quests show up in three places:
+
+- **Quest button** in the top header – a quick popover that lists your active quests, your progress
+  on each, and any rewards waiting to be claimed.
+- **Mobile feed bar** – the same quest button is available in the action bar above the feed on
+  mobile.
+- **Game Center** at [https://app.daily.dev/game-center](https://app.daily.dev/game-center) – the
+  full hub for quests, levels, streaks, and milestones.
+
+A small "new" indicator appears on the quest button whenever a fresh batch of quests is available.
+Opening the popover marks them as seen and clears the indicator.
+
+## Quest types
+
+There are three kinds of quests:
+
+- **Daily quests** – short objectives that refresh every day. Best for building habits like
+  visiting the explore page or checking discussions.
+- **Weekly quests** – larger objectives that refresh every week. They reward more meaningful
+  activity, such as reading a set number of posts or engaging with the community over time.
+- **Milestone quests** – long-term goals that don't rotate. They live in their own section of the
+  Game Center and unlock as you reach significant milestones on daily.dev.
+
+### Rotations
+
+Daily and weekly quests **rotate** on a schedule, swapping out completed objectives for fresh ones
+so there's always something new to work toward. When a new rotation starts, the quest button
+highlights it. The "new" badge clears the next time you open the panel.
+
+## Rewards
+
+Completing a quest unlocks one or more rewards:
+
+- **XP** – progresses your level shown on the Game Center.
+- **Reputation** – contributes to your daily.dev [reputation score](/docs/your-profile/reputation).
+- **Cores** – the in-product currency you can spend on
+  [Awards](/docs/monetization/awards) and [Boost](/docs/monetization/boost).
+
+When a quest is finished it becomes **claimable**. Tap **Claim** in the popover or on the Game
+Center to receive the reward. Unclaimed rewards stay available so you don't lose anything if you
+miss a day.
+
+## Quest streaks
+
+The Game Center tracks how consistently you complete quests:
+
+- **Current quest streak** – how many consecutive days you've completed at least one quest.
+- **Longest quest streak** – your personal best.
+
+Streaks are independent from your reading streak (see
+[Reading Streak](/docs/your-profile/weekly-goal)) and reward consistent participation across the
+full daily.dev experience.
+
+## Plus perks
+
+[Plus](/docs/plus/plus-overview) members get **additional quest slots** in both the daily and
+weekly buckets. That means more objectives in flight at once and more chances to earn rewards each
+rotation, on top of all the other Plus benefits.
+
+## Turning quests off
+
+If you'd rather not see quests, you can hide them:
+
+1. Open **Settings → Customization → Gamification**.
+2. Toggle **Show quests** off.
+
+You can also hide the level system from the same settings page if you prefer a quieter experience.
+Disabling quests removes the quest button from the header and feed and pauses quest tracking.
+
+:::tip
+Quests are designed to surface things you'd already enjoy doing on daily.dev. If a quest doesn't
+fit your style, ignore it – the rotation will swap it for something new soon.
+:::

--- a/src/components/homepage/homeNavBoxes.js
+++ b/src/components/homepage/homeNavBoxes.js
@@ -43,6 +43,7 @@ const FeatureList = [
     items: [
       { url: 'docs/key-features/feeds', text: 'Feeds' },
       { url: 'docs/key-features/following-feed', text: 'Following Feed' },
+      { url: 'docs/key-features/happening-now', text: 'Happening Now' },
       { url: 'docs/key-features/upvotes', text: 'Upvotes & Downvotes' },
       { url: 'docs/key-features/discussions', text: 'Discussions' },
       { url: 'docs/key-features/polls', text: 'Polls' },
@@ -62,6 +63,7 @@ const FeatureList = [
     items: [
       { url: 'docs/your-profile/activity', text: 'Activity' },
       { url: 'docs/your-profile/achievements', text: 'Achievements' },
+      { url: 'docs/your-profile/quests', text: 'Quests & Game Center' },
       {
         url: 'docs/your-profile/profile-experiences',
         text: 'Profile Experiences',


### PR DESCRIPTION
## Summary

Documents four recently announced daily.dev features.

- **Happening Now** — new page in Key features for the `/highlights` hub (channels, TL;DRs, digests, feed/post-page surfaces).
- **Quests & Game Center** — new page in Your profile covering daily/weekly/milestone quests, rotations, XP/Reputation/Cores rewards, quest streaks, Plus extra slots, and the gamification opt-out.
- **Skills (daily-dev-ask)** — extends the existing Public API page: renames "AI Agent Integrations" to "Skills (AI Agent Integrations)", adds a Skills overview, and updates each per-agent block (Claude Code, OpenClaw, Codex, Cursor) so users see how to install and invoke both `/daily.dev` and the new `/daily-dev-ask`.
- **Squad analytics** — adds a section to Growing Your Squad covering the Squad header stats (Posts, Views, Upvotes, Awards) and the 30-day Top members list, with a link to the deeper analytics page.

Homepage nav updated with entries for Happening Now and Quests & Game Center.

## Test plan

- [ ] Run `npm start` locally and verify the two new pages render and appear in the sidebar.
- [ ] Verify the homepage shows "Happening Now" under Key features and "Quests & Game Center" under Your profile.
- [ ] Verify the new sections render correctly inside `growing-your-squad.md` and `public-api.md`.
- [ ] Click each new internal `/docs/...` link and confirm it resolves.

Made with [Cursor](https://cursor.com)